### PR TITLE
Added cpu check type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Options and check types explained
         [-u unit of output values (k|m|g)]
         [-w warning threshold] (makes only sense if limit is set in lxc config)
         [-c critical threshold] (makes only sense if limit is set in lxc config)
+	[-s sleep in seconds between cpu checks]
         
     Types:
         mem -> Check the memory usage of the given container (thresholds in percent)
         swap -> Check the swap usage (thresholds in MB)
+        cpu -> Check cpu usage (percentage) of a container (thresholds in percent)
         auto -> Check autostart of container (-n ALL possible)
 
 
@@ -49,6 +51,9 @@ Examples (container name: lxctest01)
 
     ./check_lxc.sh -n lxctest01 -t swap -w 50 -c 70
     LXC lxctest01 CRITICAL - Used Swap: 81 MB|swap=85680128B;52428800;73400320;0;0
+ 
+    ./check_lxc.sh -n lxctest01 -t cpu -w 80 -c 90
+    LXC lxctest01 OK - CPU Usage: 27%|cpu=27%;80;90;0;0
  
 
 Enable cgroup memory for memory check

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options and check types explained
         [-u unit of output values (k|m|g)]
         [-w warning threshold] (makes only sense if limit is set in lxc config)
         [-c critical threshold] (makes only sense if limit is set in lxc config)
-	[-s sleep in seconds between cpu checks]
+        [-s sleep in seconds between cpu checks]
         
     Types:
         mem -> Check the memory usage of the given container (thresholds in percent)

--- a/check_lxc.sh
+++ b/check_lxc.sh
@@ -73,7 +73,7 @@ fi
 # Mankind needs help
 help="$0 v ${version} (c) 2013-$(date +%Y) Claudio Kuenzler
 Usage: $0 -n container -t type [-u unit] [-w warning] [-c critical]
-Options:\n\t-n name of container\n\t-t type to check (see list below)\n\t[-u unit of output values (k|m|g)]\n\t[-w warning threshold] (for memory makes only sense if limit is set in lxc config)\n\t[-c critical threshold] (for memory makes only sense if limit is set in lxc config)
+Options:\n\t-n name of container\n\t-t type to check (see list below)\n\t[-u unit of output values (k|m|g)]\n\t[-w warning threshold] (for memory makes only sense if limit is set in lxc config)\n\t[-c critical threshold] (for memory makes only sense if limit is set in lxc config)\n\t[-s sleep in seconds between cpu checks]
 Types:\n\tmem -> Check the memory usage of the given container (thresholds in percent)\n\tswap -> Check the swap usage (thresholds in MB)\n\tcpu -> Check cpu usage (percentage) of a container (thresholds in percent)\n\tauto -> Check autostart of container (-n ALL possible)"
 ################################################################################
 # Check for people who need help - aren't we all nice ;-)


### PR DESCRIPTION
Using jiffie values from the host itself (using /proc/stat) and from lxc-cgroup output (using cpuacct) one can get an idea of how many percent a LXC container is using from the host's CPU resources. It's not 100% accurate, but it should give a correct overview which container uses most cpu resources.